### PR TITLE
feat(Telegram Node): Add possibility to send message to forum topic

### DIFF
--- a/packages/nodes-base/nodes/Telegram/Telegram.node.ts
+++ b/packages/nodes-base/nodes/Telegram/Telegram.node.ts
@@ -1635,6 +1635,33 @@ export class Telegram implements INodeType {
 							'Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail‘s width and height should not exceed 320.',
 					},
 					{
+						displayName: 'Topic ID',
+						name: 'top_msg_id',
+						type: 'number',
+						default: 0,
+						displayOptions: {
+							show: {
+								operation: [
+									'pinChatMessage',
+									'sendAnimation',
+									'sendAudio',
+									'sendChatAction',
+									'sendDocument',
+									'sendLocation',
+									'sendMessage',
+									'sendMediaGroup',
+									'sendPhoto',
+									'sendSticker',
+									'sendVideo',
+									'unpinChatMessage',
+								],
+								resource: ['message'],
+							},
+						},
+						description:
+							'Unique identifier for the target Topic of the target Chat. It comes as "message_thread_id".',
+					},
+					{
 						displayName: 'Width',
 						name: 'width',
 						type: 'number',


### PR DESCRIPTION
Telegram added the ability to [topics within groups](https://telegram.org/blog/topics-in-groups-collectible-usernames/es?ln=a#topics-in-groups).

More technical information can be found at [this link](https://core.telegram.org/api/forum),
and finally, the point parameter to add to the `sendMessage` method is `top_msg_id`, according to the [API documentation](https://core.telegram.org/method/messages.sendMessage).

This PR aims to be a better solution to the already proposed https://github.com/n8n-io/n8n/pull/5746/
